### PR TITLE
two bugs in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p out
-emcc -std=c++14 -g -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_move"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s WASM=1 -s MODULARIZE=1 -Isrc/solver src/solver/main.cpp src/solver/*.cpp -o out/solver.js
+emcc -std=c++14 -g -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_move"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s WASM=1 -s MODULARIZE=1 -Isrc/solver src/solver/*.cpp -o out/solver.js
 
-sed -i '' 's:solver.wasm:out/solver.wasm:g' out/solver.js
+sed -i 's:solver.wasm:out/solver.wasm:g' out/solver.js
 echo "export { Module as default }" >> out/solver.js


### PR DESCRIPTION
Found while doing the tutorial on Windows.

When I built with build.sh in a Bash console (still on Windows 11), I got errors:
```
$ ./build.sh
emcc: warning: EXTRA_EXPORTED_RUNTIME_METHODS is deprecated, please use EXPORTED_RUNTIME_METHODS instead [-Wdeprecated]
wasm-ld: error: duplicate symbol: move
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o

wasm-ld: error: duplicate symbol: PARAMETERS_PER_BUILDING
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o

wasm-ld: error: duplicate symbol: convertParametersToBuildings(float const*, int)
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o

wasm-ld: error: duplicate symbol: mainObjective
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o

wasm-ld: error: duplicate symbol: convertBuildingsToParameters(std::__2::vector<Building, std::__2::allocator<Building>>, float*)
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o

wasm-ld: error: duplicate symbol: NUMBER_OF_COORDINATES_PER_BUILDING
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o

wasm-ld: error: duplicate symbol: main
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
>>> defined in C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o
emcc: error: 'D:/Oleg/Git/play/WASM/emsdk/upstream/bin\wasm-ld.exe -o out/solver.wasm C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\feasibilityChecker_1.o C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\geometry_2.o C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\main_0.o C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\objective_3.o C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\optimize_4.o C:\Users\sheydvo\AppData\Local\Temp\1\emscripten_temp_voysf4bb\solutionCandidate_5.o -LD:\Oleg\Git\play\WASM\emsdk\upstream\emscripten\cache\sysroot\lib\wasm32-emscripten -lGL -lal -lhtml5 -lstubs-debug -lnoexit -lc-debug -ldlmalloc -lcompiler_rt -lc++-noexcept -lc++abi-noexcept -lsockets -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --import-undefined --export-if-defined=move --export-if-defined=__start_em_asm --export-if-defined=__stop_em_asm --export-if-defined=__start_em_js --export-if-defined=__stop_em_js --export-if-defined=fflush --export=emscripten_stack_get_end --export=emscripten_stack_get_free --export=emscripten_stack_get_base --export=emscripten_stack_init --export=stackSave --export=stackRestore --export=stackAlloc --export=__wasm_call_ctors --export=__errno_location --export=__get_temp_ret --export=__set_temp_ret --export=malloc --export=__cxa_is_pointer_type --export-table -z stack-size=5242880 --initial-memory=16777216 --no-entry --max-memory=16777216 --global-base=1024' failed (returned 1)
```
```
sed: can't read s:solver.wasm:out/solver.wasm:g: No such file or directory
```

